### PR TITLE
Move `virsh pool-refresh`

### DIFF
--- a/playbooks/libvirt/openshift-cluster/tasks/configure_libvirt_storage_pool.yml
+++ b/playbooks/libvirt/openshift-cluster/tasks/configure_libvirt_storage_pool.yml
@@ -21,7 +21,3 @@
 - name: Create the libvirt storage pool for openshift
   command: 'virsh -c {{ libvirt_uri }} pool-create-as {{ libvirt_storage_pool }} dir --target {{ libvirt_storage_pool_path }}'
   when: pool_info_result.rc == 1
-
-- name: Refresh the libvirt storage pool for openshift
-  command: 'virsh -c {{ libvirt_uri }} pool-refresh {{ libvirt_storage_pool }}'
-  when: pool_info_result.rc == 1

--- a/playbooks/libvirt/openshift-cluster/tasks/launch_instances.yml
+++ b/playbooks/libvirt/openshift-cluster/tasks/launch_instances.yml
@@ -36,6 +36,9 @@
     creates: '{{ os_libvirt_storage_pool_path }}/{{ item }}_cloud-init.iso'
   with_items: instances
 
+- name: Refresh the libvirt storage pool for openshift
+  command: 'virsh -c {{ libvirt_uri }} pool-refresh {{ libvirt_storage_pool }}'
+
 - name: Create VMs drives
   command: 'virsh -c {{ libvirt_uri }} vol-create-as {{ os_libvirt_storage_pool }} {{ item }}.qcow2 10G --format qcow2 --backing-vol {{ image_name }} --backing-vol-format qcow2'
   with_items: instances


### PR DESCRIPTION
The `pool-refresh` command is used to ask libvirt to rescan the content of a volume pool.
This is used to make `libvirt` take into account volumes that were created outside of livirt control
i.e.: not with a `virsh` command.

`pool-refresh` is useless after a `pool-create` as the content is scanned at creation.
`pool-refresh` is mandatory after having created files inside an existing pool.
