### PR TITLE
Make the error message checks locale proof

### DIFF
--- a/playbooks/libvirt/openshift-cluster/tasks/configure_libvirt_network.yml
+++ b/playbooks/libvirt/openshift-cluster/tasks/configure_libvirt_network.yml
@@ -3,7 +3,7 @@
   command: "virsh -c {{ libvirt_uri }} net-info {{ libvirt_network }}"
   register: net_info_result
   changed_when: False
-  failed_when: "net_info_result.rc != 0 and 'error: Network not found:' not in net_info_result.stderr"
+  failed_when: "net_info_result.rc != 0 and 'no network with matching name' not in net_info_result.stderr"
 
 - name: Create a temp directory for the template xml file
   command: "mktemp -d /tmp/openshift-ansible-XXXXXXX"

--- a/playbooks/libvirt/openshift-cluster/tasks/configure_libvirt_storage_pool.yml
+++ b/playbooks/libvirt/openshift-cluster/tasks/configure_libvirt_storage_pool.yml
@@ -16,7 +16,7 @@
   command: "virsh -c {{ libvirt_uri }} pool-info {{ libvirt_storage_pool }}"
   register: pool_info_result
   changed_when: False
-  failed_when: "pool_info_result.rc != 0 and 'error: Storage pool not found:' not in pool_info_result.stderr"
+  failed_when: "pool_info_result.rc != 0 and 'no storage pool with matching name' not in pool_info_result.stderr"
 
 - name: Create the libvirt storage pool for openshift
   command: 'virsh -c {{ libvirt_uri }} pool-create-as {{ libvirt_storage_pool }} dir --target {{ libvirt_storage_pool_path }}'


### PR DESCRIPTION
On a computer which has a locale set, the error messages look like this:

```
$ virsh net-info foo
erreur :impossible de récupérer le réseau « foo »
erreur :Réseau non trouvé : no network with matching name 'foo'
```

```
$ virsh pool-info foo
erreur :impossible de récupérer le pool « foo »
erreur :Pool de stockage introuvable : no storage pool with matching name 'foo'
```

The classical way to make those tests locale proof is to force a given locale.
Like this:

```
$ LANG=POSIX virsh net-info foo
error: failed to get network 'foo'
error: Réseau non trouvé : no network with matching name 'foo'
```

```
$ LANG=POSIX virsh pool-info foo
error: failed to get pool 'foo'
error: Pool de stockage introuvable : no storage pool with matching name 'foo'
```

It looks like the "Network not found" or "Storage pool not found" parts of the message
are generated by the `libvirtd` daemon and are not subject to the locale of the `virsh`
client.

The clean fix consists in patching `libvirt` so that `virsh` sends its locale to the
`libvirtd` daemon.
But in the mean time, it is safer to have our playbook match the part of the message
which is not subject to the daemon locale.
